### PR TITLE
Added Environment Transfer Type

### DIFF
--- a/Common/DzRuntimePluginAction.h
+++ b/Common/DzRuntimePluginAction.h
@@ -6,6 +6,13 @@
 #include "QtCore/qfile.h"
 #include "QtCore/qtextstream.h"
 
+// Struct to remember attachment info
+struct AttachmentInfo
+{
+	DzNode* Parent;
+	DzNode* Child;
+};
+
 class DzRuntimePluginAction : public DzAction {
 	 Q_OBJECT
 public:
@@ -32,6 +39,7 @@ protected:
 	 virtual QString getDefaultMenuPath() const { return tr("&File/Send To"); }
 
 	 virtual void Export();
+	 virtual void ExportNode(DzNode* Node);
 
 	 virtual void WriteConfiguration() = 0;
 	 virtual void SetExportOptions(DzFileIOSettings &ExportOptions) = 0;
@@ -39,4 +47,11 @@ protected:
 	 // Need to temporarily rename surfaces if there is a name collision
 	 void RenameDuplicateMaterials(DzNode* Node, QList<QString>& MaterialNames, QMap<DzMaterial*, QString>& OriginalMaterialNames);
 	 void UndoRenameDuplicateMaterials(DzNode* Node, QList<QString>& MaterialNames, QMap<DzMaterial*, QString>& OriginalMaterialNames);
+
+	 // Used to find all the unique props in a scene for Environment export
+	 void GetScenePropList(DzNode* Node, QMap<QString, DzNode*>& Types);
+
+	 // During Environment export props need to get disconnected as they are exported.
+	 void DisconnectNode(DzNode* Node, QList<AttachmentInfo>& AttachmentList);
+	 void ReconnectNodes(QList<AttachmentInfo>& AttachmentList);
 };

--- a/Unreal/DazStudioPlugin/DzUnrealAction.h
+++ b/Unreal/DazStudioPlugin/DzUnrealAction.h
@@ -1,9 +1,12 @@
 #pragma once
 #include <dzaction.h>
 #include <dznode.h>
+#include <dzgeometry.h>
+#include <dzfigure.h>
 #include <dzjsonwriter.h>
 #include <QtCore/qfile.h>
 #include <QtCore/qtextstream.h>
+#include <QUuid.h>
 #include <DzRuntimePluginAction.h>
 #include "DzUnrealSubdivisionDialog.h"
 
@@ -18,6 +21,8 @@ protected:
 
 	 void executeAction();
 	 void WriteMaterials(DzNode* Node, DzJsonWriter& Stream);
+	 void WriteInstances(DzNode* Node, DzJsonWriter& Writer, QMap<QString, DzMatrix3>& WritenInstances, QList<DzGeometry*>& ExportedGeometry, QUuid ParentID = QUuid());
+	 QUuid WriteInstance(DzNode* Node, DzJsonWriter& Writer, QUuid ParentID);
 	 void WriteConfiguration();
 	 void SetExportOptions(DzFileIOSettings& ExportOptions);
 };

--- a/Unreal/DazStudioPlugin/DzUnrealDialog.cpp
+++ b/Unreal/DazStudioPlugin/DzUnrealDialog.cpp
@@ -82,6 +82,7 @@ DzUnrealDialog::DzUnrealDialog(QWidget *parent) :
 	assetTypeCombo->addItem("Skeletal Mesh");
 	assetTypeCombo->addItem("Static Mesh");
 	assetTypeCombo->addItem("Animation");
+	assetTypeCombo->addItem("Environment");
 	//assetTypeCombo->addItem("Pose");
 
 	// Morphs
@@ -198,11 +199,11 @@ DzUnrealDialog::DzUnrealDialog(QWidget *parent) :
 	if (dzScene->getFilename().length() > 0)
 	{
 		QFileInfo fileInfo = QFileInfo(dzScene->getFilename());
-		assetNameEdit->setText(fileInfo.baseName().replace(" ", "_"));
+		assetNameEdit->setText(fileInfo.baseName().remove(QRegExp("[^A-Za-z0-9_]")));
 	}
 	else if(dzScene->getPrimarySelection())
 	{
-		assetNameEdit->setText(Selection->getLabel().replace(" ", "_"));
+		assetNameEdit->setText(Selection->getLabel().remove(QRegExp("[^A-Za-z0-9_]")));
 	}
 
 	if (qobject_cast<DzSkeleton*>(Selection))

--- a/Unreal/UnrealPlugin/DazToUnreal/Source/DazToUnreal/Private/DazToUnrealEnvironment.cpp
+++ b/Unreal/UnrealPlugin/DazToUnreal/Source/DazToUnreal/Private/DazToUnrealEnvironment.cpp
@@ -1,0 +1,67 @@
+#include "DazToUnrealEnvironment.h"
+#include "DazToUnrealSettings.h"
+#include "DazToUnrealUtils.h"
+#include "Dom/JsonObject.h"
+#include "EditorLevelLibrary.h"
+#include "Math/UnrealMathUtility.h"
+
+void FDazToUnrealEnvironment::ImportEnvironment(TSharedPtr<FJsonObject> JsonObject)
+{
+	// Get the list of instances
+	const UDazToUnrealSettings* CachedSettings = GetDefault<UDazToUnrealSettings>();
+	TArray<TSharedPtr<FJsonValue>> InstanceList = JsonObject->GetArrayField(TEXT("Instances"));
+	TMap<FString, AActor*> GuidToActor;
+	TMap<FString, FString> ParentToChild;
+	for (int32 Index = 0; Index< InstanceList.Num(); Index++)
+	{
+		TSharedPtr<FJsonObject> Instance = InstanceList[Index]->AsObject();
+
+		// Get the instance details
+		int32 Version = Instance->GetIntegerField(TEXT("Version"));
+		FString InstanceAssetName = FDazToUnrealUtils::SanitizeName(Instance->GetStringField(TEXT("InstanceAsset")));
+		double InstanceXPos = Instance->GetNumberField(TEXT("TranslationX"));
+		double InstanceYPos = Instance->GetNumberField(TEXT("TranslationZ"));
+		double InstanceZPos = Instance->GetNumberField(TEXT("TranslationY"));
+
+		double InstanceXRot = FMath::RadiansToDegrees(Instance->GetNumberField(TEXT("RotationX")));
+		double InstanceYRot = FMath::RadiansToDegrees(Instance->GetNumberField(TEXT("RotationY")));
+		double InstanceZRot = FMath::RadiansToDegrees(Instance->GetNumberField(TEXT("RotationZ")));
+
+		double ScaleXPos = Instance->GetNumberField(TEXT("ScaleX"));
+		double ScaleYPos = Instance->GetNumberField(TEXT("ScaleZ"));
+		double ScaleZPos = Instance->GetNumberField(TEXT("ScaleY"));
+
+		FString ParentId = Instance->GetStringField(TEXT("ParentID"));
+		FString InstanceId = Instance->GetStringField(TEXT("Guid"));
+
+		// Find the asset for this instance
+		FString AssetPath = CachedSettings->ImportDirectory.Path / InstanceAssetName / InstanceAssetName + TEXT(".") + InstanceAssetName;
+		UObject* InstanceObject = LoadObject<UObject>(NULL, *AssetPath, NULL, LOAD_None, NULL);
+
+		// Spawn the object into the scene
+		if (InstanceObject)
+		{
+			FVector Location = FVector(InstanceXPos, InstanceYPos, InstanceZPos);
+			FRotator Rotation = FRotator(InstanceXRot, InstanceYRot, InstanceZRot);
+			AActor* NewActor = UEditorLevelLibrary::SpawnActorFromObject(InstanceObject, Location, Rotation);
+			if (NewActor)
+			{
+				NewActor->SetActorScale3D(FVector(ScaleXPos, ScaleYPos, ScaleZPos));
+				GuidToActor.Add(InstanceId, NewActor);
+				ParentToChild.Add(ParentId, InstanceId);
+			}
+		}
+	}
+
+	// Re-create the hierarchy from Daz Studio
+	for (auto Pair : ParentToChild)
+	{
+		if (GuidToActor.Contains(Pair.Key) && GuidToActor.Contains(Pair.Value))
+		{
+			AActor* ParentActor = GuidToActor[Pair.Key];
+			AActor* ChildActor = GuidToActor[Pair.Value];
+			ChildActor->AttachToActor(ParentActor, FAttachmentTransformRules::KeepWorldTransform);
+		}
+	}
+
+}

--- a/Unreal/UnrealPlugin/DazToUnreal/Source/DazToUnreal/Public/DazToUnreal.h
+++ b/Unreal/UnrealPlugin/DazToUnreal/Source/DazToUnreal/Public/DazToUnreal.h
@@ -19,7 +19,8 @@ enum DazAssetType
 {
 	SkeletalMesh,
 	StaticMesh,
-	Animation
+	Animation,
+	Environment
 };
 
 

--- a/Unreal/UnrealPlugin/DazToUnreal/Source/DazToUnreal/Public/DazToUnrealEnvironment.h
+++ b/Unreal/UnrealPlugin/DazToUnreal/Source/DazToUnreal/Public/DazToUnrealEnvironment.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "DazToUnrealEnums.h"
+
+class FJsonObject;
+
+class FDazToUnrealEnvironment
+{
+public:
+	static void ImportEnvironment(TSharedPtr<FJsonObject> JsonObject);
+
+private:
+	
+};


### PR DESCRIPTION
Environment transfers are for transferring more complicated scenes.  Each type of object will be transferred over as a Static Mesh or Skeletal Mesh, then one will be spawned in Unreal for each one in Daz Studio with a transform to match.